### PR TITLE
cmd/graph-vulcan-assets: fix bug in setOwner

### DIFF
--- a/cmd/graph-vulcan-assets/main.go
+++ b/cmd/graph-vulcan-assets/main.go
@@ -195,20 +195,22 @@ func upsertTeam(icli inventory.Client, payload vulcan.AssetPayload) (inventory.T
 }
 
 // setOwner sets the owner of an assset. If the owns relation already exists,
-// it does not update it.
+// the original [inventory.OwnsResp.StartTime] is used.
 func setOwner(icli inventory.Client, asset inventory.AssetResp, team inventory.TeamResp) error {
 	owners, err := icli.Owners(asset.ID, inventory.Pagination{})
 	if err != nil {
 		return fmt.Errorf("could not get owners: %w", err)
 	}
 
+	startTime := time.Now()
 	for _, o := range owners {
 		if o.TeamID == team.ID {
-			return nil
+			startTime = o.StartTime
+			break
 		}
 	}
 
-	if _, err := icli.UpsertOwner(asset.ID, team.ID, time.Now(), time.Time{}); err != nil {
+	if _, err := icli.UpsertOwner(asset.ID, team.ID, startTime, time.Time{}); err != nil {
 		return fmt.Errorf("could not upsert owner: %w", err)
 	}
 

--- a/cmd/graph-vulcan-assets/main_test.go
+++ b/cmd/graph-vulcan-assets/main_test.go
@@ -161,6 +161,10 @@ var (
 				Identifier: "team1",
 				Name:       "team1 name",
 			},
+			{
+				Identifier: "team2",
+				Name:       "team2 name",
+			},
 		},
 		Assets: []tdAsset{
 			{
@@ -323,6 +327,20 @@ var (
 				Owners: []tdOwns{
 					{
 						Team:    "team1",
+						Expired: false,
+					},
+				},
+			},
+			{
+				ID: tdAssetID{
+					Type:       "Hostname",
+					Identifier: "asset5.example.com",
+				},
+				Expired: false,
+				Parents: nil,
+				Owners: []tdOwns{
+					{
+						Team:    "team2",
 						Expired: false,
 					},
 				},

--- a/cmd/graph-vulcan-assets/testdata/messages.json
+++ b/cmd/graph-vulcan-assets/testdata/messages.json
@@ -145,6 +145,35 @@
 
 
   {
+    "key": "team2/asset5",
+    "value": "{\"Id\":\"asset5\",\"Team\":{\"Id\":\"team2\",\"Name\":\"team2 name\",\"Description\":\"team2 description\",\"Tag\":\"asset5-tag\"},\"Alias\":\"asset5 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset5.example.com\",\"Annotations\":[]}",
+    "metadata": [
+      { "key": "version", "value": "0.1.2" },
+      { "key": "type", "value": "Hostname" },
+      { "key": "identifier", "value": "asset5.example.com" }
+    ]
+  },
+  {
+    "key": "team2/asset5",
+    "value": null,
+    "metadata": [
+      { "key": "version", "value": "0.1.2" },
+      { "key": "type", "value": "Hostname" },
+      { "key": "identifier", "value": "asset5.example.com" }
+    ]
+  },
+  {
+    "key": "team2/asset5",
+    "value": "{\"Id\":\"asset5\",\"Team\":{\"Id\":\"team2\",\"Name\":\"team2 name\",\"Description\":\"team2 description\",\"Tag\":\"asset5-tag\"},\"Alias\":\"asset5 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset5.example.com\",\"Annotations\":[]}",
+    "metadata": [
+      { "key": "version", "value": "0.1.2" },
+      { "key": "type", "value": "Hostname" },
+      { "key": "identifier", "value": "asset5.example.com" }
+    ]
+  },
+
+
+  {
     "key": "invalid message",
     "value": "{",
     "metadata": [


### PR DESCRIPTION
Until now, setOwner would only upsert an owns relationship if it didn't exist.
However, this is not correct, because there could be an owns relationship that
exists and is expired. In that case, setOwner should remove its EndTime and
preserve the original StartTime.