### PR TITLE
cmd/graph-vulcan-assets: normalize AWS account ID

### DIFF
--- a/cmd/graph-vulcan-assets/main.go
+++ b/cmd/graph-vulcan-assets/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/adevinta/graph-vulcan-assets/inventory"
@@ -42,9 +43,9 @@ func run(ctx context.Context, cfg config) error {
 	}
 
 	kcfg := map[string]any{
-		"bootstrap.servers":  cfg.KafkaBootstrapServers,
-		"group.id":           cfg.KafkaGroupID,
-		"auto.offset.reset":  "earliest",
+		"bootstrap.servers": cfg.KafkaBootstrapServers,
+		"group.id":          cfg.KafkaGroupID,
+		"auto.offset.reset": "earliest",
 	}
 
 	if cfg.KafkaUsername != "" && cfg.KafkaPassword != "" {
@@ -216,10 +217,17 @@ func setOwner(icli inventory.Client, asset inventory.AssetResp, team inventory.T
 	return nil
 }
 
-// setAWSAccount sets the parent AWS account of an assset.
+// setAWSAccount sets the parent AWS account of an assset. It takes care of
+// normalizing the AWS account ID, so it always has the long format
+// "arn:aws:iam::000000000000:root".
 func setAWSAccount(icli inventory.Client, asset inventory.AssetResp, awsAccount string) error {
+	normAWSAccount, err := normalizeAWSAccountID(awsAccount)
+	if err != nil {
+		return fmt.Errorf("could not normalize AWS account ID: %w", err)
+	}
+
 	payload := vulcan.AssetPayload{
-		Identifier: awsAccount,
+		Identifier: normAWSAccount,
 		AssetType:  vulcan.AssetType("AWSAccount"),
 	}
 	assetAWSAccount, err := upsertAsset(icli, payload)
@@ -232,6 +240,25 @@ func setAWSAccount(icli inventory.Client, asset inventory.AssetResp, awsAccount 
 	}
 
 	return nil
+}
+
+var (
+	shortAWSAccountRe = regexp.MustCompile(`^[0-9]{12}$`)
+	longAWSAccountRe  = regexp.MustCompile(`^arn:aws:iam::[0-9]{12}:root$`)
+)
+
+// normalizeAWSAccountID normalizes the provided AWS account ID. The returned
+// ID will always follows the format "arn:aws:iam::000000000000:root".
+func normalizeAWSAccountID(id string) (string, error) {
+	if longAWSAccountRe.MatchString(id) {
+		return id, nil
+	}
+
+	if shortAWSAccountRe.MatchString(id) {
+		return fmt.Sprintf("arn:aws:iam::%v:root", id), nil
+	}
+
+	return "", fmt.Errorf("invalid AWS account id format: %v", id)
 }
 
 // expireAsset expires the provided asset, which means:

--- a/cmd/graph-vulcan-assets/main.go
+++ b/cmd/graph-vulcan-assets/main.go
@@ -45,7 +45,6 @@ func run(ctx context.Context, cfg config) error {
 		"bootstrap.servers":  cfg.KafkaBootstrapServers,
 		"group.id":           cfg.KafkaGroupID,
 		"auto.offset.reset":  "earliest",
-		"enable.auto.commit": false,
 	}
 
 	if cfg.KafkaUsername != "" && cfg.KafkaPassword != "" {

--- a/cmd/graph-vulcan-assets/main_test.go
+++ b/cmd/graph-vulcan-assets/main_test.go
@@ -177,7 +177,7 @@ var (
 					{
 						Parent: tdAssetID{
 							Type:       "AWSAccount",
-							Identifier: "aws0",
+							Identifier: "arn:aws:iam::000000000000:root",
 						},
 						Expired: false,
 					},
@@ -203,7 +203,7 @@ var (
 					{
 						Parent: tdAssetID{
 							Type:       "AWSAccount",
-							Identifier: "aws0",
+							Identifier: "arn:aws:iam::000000000000:root",
 						},
 						Expired: false,
 					},
@@ -225,7 +225,7 @@ var (
 					{
 						Parent: tdAssetID{
 							Type:       "AWSAccount",
-							Identifier: "aws0",
+							Identifier: "arn:aws:iam::000000000000:root",
 						},
 						Expired: false,
 					},
@@ -247,7 +247,7 @@ var (
 					{
 						Parent: tdAssetID{
 							Type:       "AWSAccount",
-							Identifier: "aws1",
+							Identifier: "arn:aws:iam::111111111111:root",
 						},
 						Expired: true,
 					},
@@ -273,7 +273,7 @@ var (
 					{
 						Parent: tdAssetID{
 							Type:       "AWSAccount",
-							Identifier: "aws2",
+							Identifier: "arn:aws:iam::222222222222:root",
 						},
 						Expired: true,
 					},
@@ -288,7 +288,7 @@ var (
 			{
 				ID: tdAssetID{
 					Type:       "AWSAccount",
-					Identifier: "aws0",
+					Identifier: "arn:aws:iam::000000000000:root",
 				},
 				Expired: false,
 				Parents: nil,
@@ -302,7 +302,7 @@ var (
 			{
 				ID: tdAssetID{
 					Type:       "AWSAccount",
-					Identifier: "aws1",
+					Identifier: "arn:aws:iam::111111111111:root",
 				},
 				Expired: true,
 				Parents: nil,
@@ -320,7 +320,7 @@ var (
 			{
 				ID: tdAssetID{
 					Type:       "AWSAccount",
-					Identifier: "aws2",
+					Identifier: "arn:aws:iam::222222222222:root",
 				},
 				Expired: false,
 				Parents: nil,
@@ -643,6 +643,54 @@ func TestReadConfig(t *testing.T) {
 
 			if diff := cmp.Diff(tt.wantConfig, config); diff != "" {
 				t.Errorf("messages mismatch (-want +got):\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestNormalizeAWSAccountID(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		wantID     string
+		wantNilErr bool
+	}{
+		{
+			name:       "long ID",
+			id:         "arn:aws:iam::123456789012:root",
+			wantID:     "arn:aws:iam::123456789012:root",
+			wantNilErr: true,
+		},
+		{
+			name:       "short ID",
+			id:         "123456789012",
+			wantID:     "arn:aws:iam::123456789012:root",
+			wantNilErr: true,
+		},
+		{
+			name:       "invalid long ID",
+			id:         "arn:aws:iam::12345abc9012:root",
+			wantID:     "",
+			wantNilErr: false,
+		},
+		{
+			name:       "invalid short ID",
+			id:         "12345abc9012",
+			wantID:     "",
+			wantNilErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, err := normalizeAWSAccountID(tt.id)
+
+			if (err == nil) != tt.wantNilErr {
+				t.Errorf("unexpected error: wantNilErr=%v, got=%v", tt.wantNilErr, err)
+			}
+
+			if gotID != tt.wantID {
+				t.Errorf("unexpected ID: want=%v, got=%v", tt.wantID, gotID)
 			}
 		})
 	}

--- a/cmd/graph-vulcan-assets/testdata/messages.json
+++ b/cmd/graph-vulcan-assets/testdata/messages.json
@@ -1,7 +1,7 @@
 [
   {
     "key": "team0/asset0",
-    "value": "{\"Id\":\"asset0\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"asset0-tag\"},\"Alias\":\"asset0 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset0.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"aws0\"}]}",
+    "value": "{\"Id\":\"asset0\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"asset0-tag\"},\"Alias\":\"asset0 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset0.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"000000000000\"}]}",
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "Hostname" },
@@ -10,7 +10,7 @@
   },
   {
     "key": "team0/asset1",
-    "value": "{\"Id\":\"asset1\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"asset1-tag\"},\"Alias\":\"asset1 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset1.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"aws0\"}]}",
+    "value": "{\"Id\":\"asset1\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"asset1-tag\"},\"Alias\":\"asset1 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset1.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"arn:aws:iam::000000000000:root\"}]}",
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "Hostname" },
@@ -19,7 +19,7 @@
   },
   {
     "key": "team0/asset2",
-    "value": "{\"Id\":\"asset2\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"asset2-tag\"},\"Alias\":\"asset2 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset2.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"aws0\"}]}",
+    "value": "{\"Id\":\"asset2\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"asset2-tag\"},\"Alias\":\"asset2 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset2.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"000000000000\"}]}",
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "Hostname" },
@@ -28,7 +28,7 @@
   },
   {
     "key": "team0/asset3",
-    "value": "{\"Id\":\"asset3\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"asset3-tag\"},\"Alias\":\"asset3 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset3.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"aws1\"}]}",
+    "value": "{\"Id\":\"asset3\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"asset3-tag\"},\"Alias\":\"asset3 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset3.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"111111111111\"}]}",
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "Hostname" },
@@ -37,28 +37,28 @@
   },
 
   {
-    "key": "team0/aws0",
-    "value": "{\"Id\":\"aws0\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"aws0-tag\"},\"Alias\":\"aws0 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"AWSAccount\",\"Identifier\":\"aws0\",\"Annotations\":[]}",
+    "key": "team0/arn:aws:iam::000000000000:root",
+    "value": "{\"Id\":\"aws0\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"aws0-tag\"},\"Alias\":\"aws0 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"AWSAccount\",\"Identifier\":\"arn:aws:iam::000000000000:root\",\"Annotations\":[]}",
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "AWSAccount" },
-      { "key": "identifier", "value": "aws0" }
+      { "key": "identifier", "value": "arn:aws:iam::000000000000:root" }
     ]
   },
   {
-    "key": "team0/aws1",
-    "value": "{\"Id\":\"aws1\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"aws1-tag\"},\"Alias\":\"aws1 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"AWSAccount\",\"Identifier\":\"aws1\",\"Annotations\":[]}",
+    "key": "team0/arn:aws:iam::111111111111:root",
+    "value": "{\"Id\":\"aws1\",\"Team\":{\"Id\":\"team0\",\"Name\":\"team0 name\",\"Description\":\"team0 description\",\"Tag\":\"aws1-tag\"},\"Alias\":\"aws1 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"AWSAccount\",\"Identifier\":\"arn:aws:iam::111111111111:root\",\"Annotations\":[]}",
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "AWSAccount" },
-      { "key": "identifier", "value": "aws1" }
+      { "key": "identifier", "value": "arn:aws:iam::111111111111:root" }
     ]
   },
 
 
   {
     "key": "team1/asset0",
-    "value": "{\"Id\":\"asset0\",\"Team\":{\"Id\":\"team1\",\"Name\":\"team1 name\",\"Description\":\"team1 description\",\"Tag\":\"asset0-tag\"},\"Alias\":\"asset0 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset0.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"aws0\"}]}",
+    "value": "{\"Id\":\"asset0\",\"Team\":{\"Id\":\"team1\",\"Name\":\"team1 name\",\"Description\":\"team1 description\",\"Tag\":\"asset0-tag\"},\"Alias\":\"asset0 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset0.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"000000000000\"}]}",
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "Hostname" },
@@ -67,7 +67,7 @@
   },
   {
     "key": "team1/asset3",
-    "value": "{\"Id\":\"asset3\",\"Team\":{\"Id\":\"team1\",\"Name\":\"team1 name\",\"Description\":\"team1 description\",\"Tag\":\"asset3-tag\"},\"Alias\":\"asset3 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset3.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"aws1\"}]}",
+    "value": "{\"Id\":\"asset3\",\"Team\":{\"Id\":\"team1\",\"Name\":\"team1 name\",\"Description\":\"team1 description\",\"Tag\":\"asset3-tag\"},\"Alias\":\"asset3 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset3.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"111111111111\"}]}",
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "Hostname" },
@@ -76,7 +76,7 @@
   },
   {
     "key": "team1/asset4",
-    "value": "{\"Id\":\"asset4\",\"Team\":{\"Id\":\"team1\",\"Name\":\"team1 name\",\"Description\":\"team1 description\",\"Tag\":\"asset4-tag\"},\"Alias\":\"asset4 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset4.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"aws2\"}]}",
+    "value": "{\"Id\":\"asset4\",\"Team\":{\"Id\":\"team1\",\"Name\":\"team1 name\",\"Description\":\"team1 description\",\"Tag\":\"asset4-tag\"},\"Alias\":\"asset4 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset4.example.com\",\"Annotations\":[{\"Key\":\"discovery/aws/account\",\"Value\":\"222222222222\"}]}",
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "Hostname" },
@@ -85,21 +85,21 @@
   },
 
   {
-    "key": "team1/aws1",
-    "value": "{\"Id\":\"aws1\",\"Team\":{\"Id\":\"team1\",\"Name\":\"team1 name\",\"Description\":\"team1 description\",\"Tag\":\"aws1-tag\"},\"Alias\":\"aws1 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"AWSAccount\",\"Identifier\":\"aws1\",\"Annotations\":[]}",
+    "key": "team1/arn:aws:iam::111111111111:root",
+    "value": "{\"Id\":\"aws1\",\"Team\":{\"Id\":\"team1\",\"Name\":\"team1 name\",\"Description\":\"team1 description\",\"Tag\":\"aws1-tag\"},\"Alias\":\"aws1 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"AWSAccount\",\"Identifier\":\"arn:aws:iam::111111111111:root\",\"Annotations\":[]}",
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "AWSAccount" },
-      { "key": "identifier", "value": "aws1" }
+      { "key": "identifier", "value": "arn:aws:iam::111111111111:root" }
     ]
   },
   {
-    "key": "team1/aws2",
-    "value": "{\"Id\":\"aws2\",\"Team\":{\"Id\":\"team1\",\"Name\":\"team1 name\",\"Description\":\"team1 description\",\"Tag\":\"aws2-tag\"},\"Alias\":\"aws2 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"AWSAccount\",\"Identifier\":\"aws2\",\"Annotations\":[]}",
+    "key": "team1/arn:aws:iam::222222222222:root",
+    "value": "{\"Id\":\"aws2\",\"Team\":{\"Id\":\"team1\",\"Name\":\"team1 name\",\"Description\":\"team1 description\",\"Tag\":\"aws2-tag\"},\"Alias\":\"aws2 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"AWSAccount\",\"Identifier\":\"arn:aws:iam::222222222222:root\",\"Annotations\":[]}",
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "AWSAccount" },
-      { "key": "identifier", "value": "aws2" }
+      { "key": "identifier", "value": "arn:aws:iam::222222222222:root" }
     ]
   },
 
@@ -115,21 +115,21 @@
   },
 
   {
-    "key": "team0/aws1",
+    "key": "team0/arn:aws:iam::111111111111:root",
     "value": null,
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "AWSAccount" },
-      { "key": "identifier", "value": "aws1" }
+      { "key": "identifier", "value": "arn:aws:iam::111111111111:root" }
     ]
   },
   {
-    "key": "team1/aws1",
+    "key": "team1/arn:aws:iam::111111111111:root",
     "value": null,
     "metadata": [
       { "key": "version", "value": "0.1.2" },
       { "key": "type", "value": "AWSAccount" },
-      { "key": "identifier", "value": "aws1" }
+      { "key": "identifier", "value": "arn:aws:iam::111111111111:root" }
     ]
   },
 


### PR DESCRIPTION
AWS account ID annotations not always use the preferred long format
"arn:aws:iam::000000000000:root", causing the creation of two assets for the
same AWS account (e.g. "000000000000" and "arn:aws:iam::000000000000:root").
This PR fixes this by normalizing the AWS account before setting asset parents.