### PR TITLE
cmd/graph-vulcan-assets: handle receiving a tombstone first

### DIFF
--- a/cmd/graph-vulcan-assets/main.go
+++ b/cmd/graph-vulcan-assets/main.go
@@ -273,8 +273,12 @@ func expireAsset(icli inventory.Client, payload vulcan.AssetPayload) error {
 		return fmt.Errorf("could not get assets: %w", err)
 	}
 
-	if len(assets) != 1 {
-		return errors.New("unknown or duplicated asset")
+	if len(assets) == 0 {
+		// The asset does not exist, so nothing needs to be done.
+		return nil
+	}
+	if len(assets) > 1 {
+		return errors.New("duplicated asset")
 	}
 
 	teams, err := icli.Teams(payload.Team.ID, inventory.Pagination{})
@@ -282,8 +286,12 @@ func expireAsset(icli inventory.Client, payload vulcan.AssetPayload) error {
 		return fmt.Errorf("could not get teams: %w", err)
 	}
 
-	if len(teams) != 1 {
-		return errors.New("unknown or duplicated team")
+	if len(teams) == 0 {
+		// The team does not exist, so nothing needs to be done.
+		return nil
+	}
+	if len(teams) > 1 {
+		return errors.New("duplicated team")
 	}
 
 	now := time.Now()

--- a/cmd/graph-vulcan-assets/testdata/messages.json
+++ b/cmd/graph-vulcan-assets/testdata/messages.json
@@ -174,7 +174,36 @@
 
 
   {
-    "key": "invalid message",
+    "key": "team3/asset6",
+    "value": "{\"Id\":\"asset6\",\"Team\":{\"Id\":\"team3\",\"Name\":\"team3 name\",\"Description\":\"team3 description\",\"Tag\":\"asset6-tag\"},\"Alias\":\"asset6 alias\",\"Rolfp\":\"R:0/O:1/L:0/F:1/P:0+S:1\",\"Scannable\":true,\"AssetType\":\"Hostname\",\"Identifier\":\"asset6.example.com\",\"Annotations\":[]}",
+    "metadata": [
+      { "key": "version", "value": "0.1.2" },
+      { "key": "type", "value": "Hostname" },
+      { "key": "identifier", "value": "asset6.example.com" }
+    ]
+  },
+  {
+    "key": "team3/asset999",
+    "value": null,
+    "metadata": [
+      { "key": "version", "value": "0.1.2" },
+      { "key": "type", "value": "Hostname" },
+      { "key": "identifier", "value": "asset999.example.com" }
+    ]
+  },
+  {
+    "key": "team999/asset6",
+    "value": null,
+    "metadata": [
+      { "key": "version", "value": "0.1.2" },
+      { "key": "type", "value": "Hostname" },
+      { "key": "identifier", "value": "asset6.example.com" }
+    ]
+  },
+
+
+  {
+    "key": "ENDTESTDATA",
     "value": "{",
     "metadata": [
       { "key": "version", "value": "0.1.2" },

--- a/vulcan/vulcan.go
+++ b/vulcan/vulcan.go
@@ -103,12 +103,12 @@ func (c Client) ProcessAssets(ctx context.Context, h AssetHandler) error {
 
 		if msg.Value != nil {
 			if err := json.Unmarshal(msg.Value, &payload); err != nil {
-				return fmt.Errorf("could not unmarshal asset with ID %v: %w", id, err)
+				return fmt.Errorf("could not unmarshal asset with ID %q: %w", id, err)
 			}
 		} else {
 			teamID, assetID, err := parseMessageID(id)
 			if err != nil {
-				return fmt.Errorf("could not parse message ID %v: %w", id, err)
+				return fmt.Errorf("could not parse message ID %q: %w", id, err)
 			}
 
 			payload.ID = assetID


### PR DESCRIPTION
This PR modifies cmd/graph-vulcan-assets to handle the case of receiving a
tombstone first.